### PR TITLE
Adding GOCACHE variable, needed for go version 1.12

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 	os.Setenv("PATH", fmt.Sprintf("%s%s%s", gobin, string(os.PathListSeparator), os.Getenv("PATH")))
 	defer os.Setenv("PATH", oldpath)
 
-	env := []string{fmt.Sprintf("PATH=%s", path), fmt.Sprintf("GOPATH=%s", gopath), fmt.Sprintf("GOBIN=%s", gobin)}
+	env := []string{fmt.Sprintf("PATH=%s", path), fmt.Sprintf("GOPATH=%s", gopath), fmt.Sprintf("GOBIN=%s", gobin), fmt.Sprintf("GOCACHE=%s", gopath)}
 	args := append([]string{"install"}, packages...)
 	if out, err := doexec("go", gopath, args, env); err != nil {
 		print(string(out))


### PR DESCRIPTION
go1.12 needs GOCACHE variable to be present. I re-used for that temp directory for gopath.